### PR TITLE
Admin invoice total revenue

### DIFF
--- a/app/controllers/admin_invoices_controller.rb
+++ b/app/controllers/admin_invoices_controller.rb
@@ -6,4 +6,10 @@ class AdminInvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
   end
+
+  def update
+    invoice = Invoice.find(params[:id])
+    invoice.update(status: params[:update_status])
+    redirect_to "/admin/invoices/#{params[:id]}"
+  end
 end

--- a/app/views/admin_invoices/show.html.erb
+++ b/app/views/admin_invoices/show.html.erb
@@ -3,7 +3,12 @@
   <p><strong>Invoice id: </strong><%= @invoice.id %></p>
   <p><strong>Invoice status: </strong><%= @invoice.status %></p>
   <p><strong>Invoice created time: </strong><%= @invoice.created_at.strftime("%A, %b %d, %Y") %></p>
-  <p><strong>Invoice customer: </strong><%= @invoice.customer.first_name %> <%= @invoice.customer.last_name%></p>
+  <p><strong>Invoice customer: </strong><%= @invoice.customer.first_name %><%= @invoice.customer.last_name%></p>
+  <p><strong>Total revenue generated: </strong><%= number_to_currency(@invoice.total_rev/100, precision: 2) %></p>
+    <%= form_with url: "/admin/invoices/#{@invoice.id}/", method: :patch, local: true do |f| %>
+        <%= f.select :update_status, ["in progress", "completed", "cancelled"], selected: @invoice.status %>
+    <%= f.submit :update_invoice_status %>
+  <% end %>
 </div>
 <hr>
 
@@ -14,7 +19,6 @@
   <p><strong>Item name: </strong><%= invoice_item.item.name %></p>
   <p><strong>Quantity: </strong><%= invoice_item.quantity %></p>
   <p><strong>Sale price: </strong> <%= number_to_currency(invoice_item.unit_price/100, precision: 2) %>
-  <p><strong>Status: </strong><%= invoice_item.status %> </p>
+  <p><strong>Status: </strong><%= invoice_item.status %></p>
 </div>
-<p></p>
 <% end %>

--- a/app/views/admin_invoices/show.html.erb
+++ b/app/views/admin_invoices/show.html.erb
@@ -8,7 +8,7 @@
   <p><strong>Status:
     <%= form_with url: "/admin/invoices/#{@invoice.id}/", method: :patch, local: true do |f| %>
         <%= f.select :update_status, ["in progress", "completed", "cancelled"], selected: @invoice.status %>
-    <%= f.submit :update_invoice_status %>
+    <%= f.submit "Update Invoice Status" %>
   <% end %>
   </p>
 </div>

--- a/app/views/admin_invoices/show.html.erb
+++ b/app/views/admin_invoices/show.html.erb
@@ -5,10 +5,12 @@
   <p><strong>Invoice created time: </strong><%= @invoice.created_at.strftime("%A, %b %d, %Y") %></p>
   <p><strong>Invoice customer: </strong><%= @invoice.customer.first_name %><%= @invoice.customer.last_name%></p>
   <p><strong>Total revenue generated: </strong><%= number_to_currency(@invoice.total_rev/100, precision: 2) %></p>
+  <p><strong>Status:
     <%= form_with url: "/admin/invoices/#{@invoice.id}/", method: :patch, local: true do |f| %>
         <%= f.select :update_status, ["in progress", "completed", "cancelled"], selected: @invoice.status %>
     <%= f.submit :update_invoice_status %>
   <% end %>
+  </p>
 </div>
 <hr>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,6 @@ Rails.application.routes.draw do
 
   get '/admin/invoices', to: 'admin_invoices#index'
   get '/admin/invoices/:id', to: 'admin_invoices#show'
+  patch '/admin/invoices/:id', to: 'admin_invoices#update'
 
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -64,4 +64,31 @@ RSpec.describe 'Admin invoice show page' do
     end
   end
 
+  it 'shows total revenue for the invoice' do
+    @invoiceitem2.update(quantity: 3)
+    visit "/admin/invoices/#{@invoice1.id}"
+
+    expect(page).to have_content("Total revenue generated: $4.00")
+  end
+
+  it 'shows the invoice status as a select field that is editable, with a submit button' do
+    expected = find_field(:update_status).value
+
+    expect(expected).to eq("in progress")
+
+    visit "/admin/invoices/#{@invoice2.id}"
+
+    expected = find_field(:update_status).value
+
+    expect(expected).to eq("completed")
+
+    select "cancelled", from: :update_status
+
+    click_on :update_invoice_status
+
+    expected = find_field(:update_status).value
+
+    expect(expected).to eq("cancelled")
+  end
+
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'Admin invoice show page' do
 
     select "cancelled", from: :update_status
 
-    click_on :update_invoice_status
+    click_on "Update Invoice Status"
 
     expected = find_field(:update_status).value
 


### PR DESCRIPTION
1.  Adds total revenue to admin invoice show page
2. Refactors invoice status to be shown as a dropdown select field, now functions as an on-page status update function